### PR TITLE
Improve categories endpoint performance

### DIFF
--- a/backend/routes/categories.py
+++ b/backend/routes/categories.py
@@ -11,12 +11,12 @@ supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 @router.get("/categories")
 def get_categories():
     try:
-        response = supabase.table("ia_tools").select("category").execute()
-        if not response.data:
-            return []
-        categories = list(set([item["category"] for item in response.data if item.get("category")]))
-        categories.sort()
+        params = {"select": "category", "distinct": "category", "order": "category"}
+        response = supabase.postgrest.session.get("ia_tools", params=params)
+        response.raise_for_status()
+        data = response.json()
+        categories = [item["category"] for item in data if item.get("category")]
         return categories
     except Exception as e:
         print("❌ Error al obtener categorías:", str(e))
-    raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=500, detail=str(e))

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Category from './components/CategoryList';
 
 function App() {


### PR DESCRIPTION
## Summary
- optimize `/categories` endpoint to retrieve unique categories directly from Supabase using query params
- remove unused React import to satisfy lint rules

## Testing
- `npm run lint`
- `python -m py_compile backend/routes/categories.py`


------
https://chatgpt.com/codex/tasks/task_e_688a07d1cc908324bae76a711594d610