### PR TITLE
Use supabase query builder in categories route

### DIFF
--- a/backend/routes/categories.py
+++ b/backend/routes/categories.py
@@ -11,11 +11,11 @@ supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 @router.get("/categories")
 def get_categories():
     try:
-        params = {"select": "category", "distinct": "category", "order": "category"}
-        response = supabase.postgrest.session.get("ia_tools", params=params)
-        response.raise_for_status()
-        data = response.json()
-        categories = [item["category"] for item in data if item.get("category")]
+        query = supabase.table("ia_tools").select("category")
+        query.params = query.params.set("distinct", "category")
+        query = query.order("category")
+        response = query.execute()
+        categories = [r["category"] for r in response.data if r.get("category")]
         return categories
     except Exception as e:
         print("❌ Error al obtener categorías:", str(e))


### PR DESCRIPTION
## Summary
- replace `postgrest.session.get` with query builder in `get_categories`
- keep error logging and HTTP 500 response on failure

## Testing
- `python -m py_compile backend/routes/categories.py`

------
https://chatgpt.com/codex/tasks/task_e_688a10b007208324929bf164aaf7fc7a