### PR TITLE
Remove duplicated tools route

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -25,21 +25,3 @@ app.add_middleware(
 app.include_router(categories_router)
 app.include_router(tools_router)
 
-SUPABASE_URL = os.getenv("SUPABASE_URL")
-SUPABASE_API_KEY = os.getenv("SUPABASE_API_KEY")
-
-@app.get("/tools")
-async def get_tools():
-    async with httpx.AsyncClient() as client:
-        response = await client.get(
-            f"{SUPABASE_URL}/rest/v1/ia_tools",
-            headers={
-                "apikey": SUPABASE_API_KEY,
-                "Authorization": f"Bearer {SUPABASE_API_KEY}",
-                "Content-Type": "application/json"
-            },
-            params={"select": "*"}
-        )
-    response.raise_for_status()
-    return response.json()
-


### PR DESCRIPTION
## Summary
- clean up `backend/main.py` by removing the hard-coded `/tools` endpoint
- keep router-based implementation as the single source for `/tools`

## Testing
- `python3 -m py_compile backend/main.py`
- `uvicorn main:app --port 8000 --host 0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_688a110e6f4c83249e21cfbe4b81b104