### PR TITLE
Refactor categories route to dedupe client-side

### DIFF
--- a/backend/routes/categories.py
+++ b/backend/routes/categories.py
@@ -12,10 +12,17 @@ supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 def get_categories():
     try:
         query = supabase.table("ia_tools").select("category")
-        query.params = query.params.set("distinct", "category")
         query = query.order("category")
         response = query.execute()
-        categories = [r["category"] for r in response.data if r.get("category")]
+
+        seen = set()
+        categories = []
+        for r in response.data:
+            category = r.get("category")
+            if category and category not in seen:
+                seen.add(category)
+                categories.append(category)
+
         return categories
     except Exception as e:
         print("❌ Error al obtener categorías:", str(e))


### PR DESCRIPTION
## Summary
- retrieve categories without Supabase `distinct`
- deduplicate them in Python and keep category ordering

## Testing
- `python -m py_compile backend/routes/categories.py`
- `npm --prefix frontend run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a179809fc8324962f82e37f97c8f5