### PR TITLE
Add loading overlay and initial animation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Category from './components/CategoryList';
 
 function App() {
@@ -28,10 +28,17 @@ function App() {
     }));
   };
 
+  // Muestra una animación de carga al iniciar la aplicación
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => setLoading(false), 1000);
+    return () => clearTimeout(timer);
+  }, []);
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-4">
       {/* Encabezado fijo */}
-      <div className="sticky top-0 z-10 bg-white pb-4 pt-2 shadow">
+      <div className="sticky top-0 z-40 bg-white pb-4 pt-2 shadow">
         <h1 className="text-2xl font-bold mb-4">Explorá herramientas de IA</h1>
         <Category
           onSelectCategory={(cat) => {
@@ -41,11 +48,13 @@ function App() {
         />
       </div>
 
-      {/* Loader centrado debajo de categorías */}
+      {/* Animación de carga superpuesta */}
       {loading && (
-        <div className="flex flex-col items-center justify-center mt-6 mb-4 min-h-[100px]">
-          <div className="h-10 w-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
-          <p className="mt-2 text-sm text-blue-600">Cargando herramientas...</p>
+        <div className="loading-overlay">
+          <div className="flex flex-col items-center">
+            <div className="loader"></div>
+            <p className="mt-2 text-sm text-blue-600">Cargando herramientas...</p>
+          </div>
         </div>
       )}
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -66,3 +66,25 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.7);
+  z-index: 20;
+}
+.loader {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 4px solid #3b82f6;
+  border-top-color: transparent;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
## Summary
- show overlay spinner when the app starts and while waiting for tools
- keep page header fixed

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b5ff5b204832480ff54d9f1723ec4